### PR TITLE
Add Zustand-based sync store

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ This is usually just done once in the root component of your app, and it provide
 This simple hook enables the backend to show toast notifications on the frontend.
 
 
+### Zustand integration
+
+For applications that already rely on [Zustand](https://github.com/pmndrs/zustand)
+for state management, the library exposes helpers to create synced stores
+outside of React components.
+
+```javascript
+import { createSyncedStore, Session } from 'ws-sync'
+import { create } from 'zustand'
+
+const session = new Session('ws://localhost:8000/ws')
+
+// Create a vanilla store and then bind it with the Zustand `create` helper
+const notesStore = createSyncedStore('NOTES', { title: '', notes: [] }, session)
+export const useNotes = create(notesStore)
+
+// Anywhere in your app you can use the store
+useNotes.getState().syncTitle('new title')
+```
+
+
 ## Development & Publishing
 
 After you make changes (don't forget to bump the version number!), run the following commands to publish the changes to npm:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "fast-json-patch": "^3.1.1",
         "immer": "^10.0.3",
         "js-file-download": "^0.4.12",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@testing-library/react-hooks": "^8.0.1",
@@ -5365,6 +5366,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fast-json-patch": "^3.1.1",
     "immer": "^10.0.3",
     "js-file-download": "^0.4.12",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "zustand": "^5.0.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,7 @@ export {
   StateWithFetch,
 } from "./sync";
 export { useRemoteToast } from "./remote-toast";
+export {
+  createSyncedStore,
+  createSyncedReducerStore,
+} from "./zustand-sync";

--- a/src/zustand-sync.ts
+++ b/src/zustand-sync.ts
@@ -1,0 +1,106 @@
+import { createStore, StoreApi } from 'zustand/vanilla'
+import { applyReducer, deepClone } from 'fast-json-patch'
+import { castImmutable, produceWithPatches, enablePatches } from 'immer'
+import { Session } from './session'
+import { Action, TaskCancel, TaskStart, SyncedReducer, StateWithSync } from './sync'
+
+enablePatches()
+
+const setEvent = (key: string) => '_SET:' + key
+const getEvent = (key: string) => '_GET:' + key
+const patchEvent = (key: string) => '_PATCH:' + key
+const actionEvent = (key: string) => '_ACTION:' + key
+const taskStartEvent = (key: string) => '_TASK_START:' + key
+const taskCancelEvent = (key: string) => '_TASK_CANCEL:' + key
+
+function extractData<S extends Record<string, any>>(initialState: S, state: any): S {
+  const data: any = {}
+  Object.keys(initialState).forEach(k => { data[k] = state[k] })
+  return data as S
+}
+
+export function createSyncedReducerStore<S extends Record<string, any>>(
+  key: string,
+  reducer: SyncedReducer<S> | undefined,
+  initialState: S,
+  session: Session,
+  sendOnInit = false
+): [StoreApi<StateWithSync<S>>, (action: Action) => void] {
+  const sendState = (state: S) => session.send(setEvent(key), state)
+  const sendPatch = (patch: any) => session.send(patchEvent(key), patch)
+  const sendAction = (action: Action) => session.send(actionEvent(key), action)
+  const startTask = (task: TaskStart) => session.send(taskStartEvent(key), task)
+  const cancelTask = (task: TaskCancel) => session.send(taskCancelEvent(key), task)
+  const sendBinary = (action: Action, data: ArrayBuffer) =>
+    session.sendBinary(actionEvent(key), action, data)
+  const fetchRemoteState = () => session.send(getEvent(key), {})
+
+  const store = createStore<StateWithSync<S>>((set, get) => {
+
+    const setters: Record<string, any> = {}
+    Object.keys(initialState).forEach(attr => {
+      const upper = attr.charAt(0).toUpperCase() + attr.slice(1)
+      setters[`set${upper}`] = (val: any) => set((state: any) => ({ ...state, [attr]: val }))
+      setters[`sync${upper}`] = (val: any) => {
+        set((state: any) => ({ ...state, [attr]: val }))
+        sendPatch([{ op: 'replace', path: `/${attr}`, value: val }])
+      }
+    })
+
+    return {
+      ...initialState,
+      ...setters,
+      fetchRemoteState,
+      sendAction,
+      startTask,
+      cancelTask,
+      sendBinary,
+    } as StateWithSync<S>
+  })
+
+  const setData = (data: S) => {
+    store.setState(state => ({ ...state, ...data }))
+  }
+  const patchData = (patch: any) => {
+    const current = extractData(initialState, store.getState())
+    const newData = patch.reduce(applyReducer, deepClone(current))
+    store.setState(state => ({ ...state, ...newData }))
+  }
+
+  const dispatch = (action: Action) => {
+    if (!reducer) return
+    const createEffect: any[] = []
+    const sync = () => createEffect.push((patch: any[]) => () => {
+      if (patch.length > 0) sendPatch(patch)
+    })
+    const delegate = (actionOverride?: Action) => createEffect.push((patch: any[]) => () => {
+      sendAction(actionOverride ?? action)
+    })
+
+    const withPatch = produceWithPatches(reducer)
+    const [newState, patch] = withPatch(castImmutable(extractData(initialState, store.getState())), action, sync, delegate)
+    setData(newState)
+    createEffect.forEach(f => f(patch)())
+  }
+
+  session.registerEvent(getEvent(key), () => {
+    const data = extractData(initialState, store.getState())
+    sendState(data)
+  })
+  session.registerEvent(setEvent(key), setData)
+  session.registerEvent(patchEvent(key), patchData)
+  session.registerEvent(actionEvent(key), dispatch)
+  if (sendOnInit) session.registerInit(key, () => sendState(extractData(initialState, store.getState())))
+
+  return [store, dispatch]
+}
+
+export function createSyncedStore<S extends Record<string, any>>(
+  key: string,
+  initialState: S,
+  session: Session,
+  sendOnInit = false
+): StoreApi<StateWithSync<S>> {
+  const [store] = createSyncedReducerStore(key, undefined, initialState, session, sendOnInit)
+  return store
+}

--- a/tests/zustand-sync.test.ts
+++ b/tests/zustand-sync.test.ts
@@ -1,0 +1,37 @@
+import { createSyncedStore } from '../src/zustand-sync'
+import { Action } from '../src'
+
+class MockSession {
+  events: Record<string, (data: any) => void> = {}
+  inits: Record<string, () => void> = {}
+  sent: { event: string; data: any }[] = []
+  send(event: string, data: any) { this.sent.push({ event, data }) }
+  sendBinary(event: string, meta: any, data: ArrayBuffer) {}
+  registerEvent(ev: string, cb: (data: any) => void) { this.events[ev] = cb }
+  deregisterEvent(ev: string) { delete this.events[ev] }
+  registerInit(key: string, cb: () => void) { this.inits[key] = cb }
+  deregisterInit(key: string) { delete this.inits[key] }
+}
+
+describe('createSyncedStore', () => {
+  test('local updates and syncing', () => {
+    const session = new MockSession()
+    const store = createSyncedStore('COUNTER', { count: 0 }, session as any)
+
+    store.getState().setCount(1)
+    expect(store.getState().count).toBe(1)
+    expect(session.sent).toHaveLength(0)
+
+    store.getState().syncCount(2)
+    expect(store.getState().count).toBe(2)
+    expect(session.sent).toEqual([
+      { event: '_PATCH:COUNTER', data: [{ op: 'replace', path: '/count', value: 2 }] },
+    ])
+
+    store.getState().fetchRemoteState()
+    expect(session.sent[1]).toEqual({ event: '_GET:COUNTER', data: {} })
+
+    session.events['_PATCH:COUNTER']([{ op: 'replace', path: '/count', value: 5 }])
+    expect(store.getState().count).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- add Zustand integration for ws-sync
- export new store helpers
- document Zustand usage
- test Zustand synced store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687139476b94832fad43968257404a30